### PR TITLE
docs: Add `narwhals.dtypes.Date` docstring example (#1528)

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -698,4 +698,23 @@ class Array(DType):
 
 
 class Date(TemporalType):
-    """Data type representing a calendar date."""
+    """Data type representing a calendar date.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> from datetime import date, timedelta
+       >>> data = [date(2024, 12, 1) + timedelta(days=d) for d in range(4)]
+       >>> ser_pd = pd.Series(data, dtype="date32[pyarrow]")
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+       >>> nw.from_native(ser_pd, series_only=True).dtype
+       Date
+       >>> nw.from_native(ser_pl, series_only=True).dtype
+       Date
+       >>> nw.from_native(ser_pa, series_only=True).dtype
+       Date
+    """


### PR DESCRIPTION
This pull request adds detailed examples to the docstring of the `Date` class in the `narwhals/dtypes.py` file. The examples demonstrate how to create date series using different libraries and convert them to the `Date` type in the `narwhals` library.

Documentation improvements:

* [`narwhals/dtypes.py`](diffhunk://#diff-753420e7b70ee2b5cc50d6c28a2bf8ad85803ceaeda92029df1c4aadb6eb394aL701-R720): Added examples to the `Date` class docstring to illustrate how to create date series using `pandas`, `polars`, and `pyarrow`, and how to convert them to the `Date` type in the `narwhals` library.* docs: Add docstring examples for Date

* Update narwhals/dtypes.py



---------


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
